### PR TITLE
Fix mysterious but repeatable clock-related failure when installing Ruby

### DIFF
--- a/definitions/ubuntu-7.10-server-amd64/postinstall.sh
+++ b/definitions/ubuntu-7.10-server-amd64/postinstall.sh
@@ -25,7 +25,20 @@ sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
 wget http://rubyforge.org/frs/download.php/71096/ruby-enterprise-1.8.7-2010.02.tar.gz
 tar xzvf ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir -p /opt/ruby/lib/ruby/gems/1.8/gems
-./ruby-enterprise-1.8.7-2010.02/installer -a /opt/ruby --no-dev-docs --dont-install-useful-gems
+
+# installer is broken, hack around it
+# see http://blog.martinlv.cawing.info/?p=93
+RUBYINST="./ruby-enterprise-1.8.7-2010.02/installer -a /opt/ruby --no-dev-docs --dont-install-useful-gems"
+HACKMSG="Ruby installer failed, trying to work around a known clock bug"
+DAY=`expr 24 '*' 3600`
+$RUBYINST || (
+    echo $HACKMSG
+    now=`date +%s`
+    sudo date -s @`expr $now '+' $DAY`
+    $RUBYINST
+    now=`date +%s`
+    sudo date -s @`expr $now '-' $DAY` )
+
 echo 'PATH=$PATH:/opt/ruby/bin/'>> /etc/profile
 rm -rf ./ruby-enterprise-1.8.7-2010.02/
 rm ruby-enterprise-1.8.7-2010.02.tar.gz


### PR DESCRIPTION
I haven't been able to find out what causes this bug, but I've seen numerous mentions of it on the net. It seems to happen often enough in VBox builds to warrant a fix, even if it technically breaks the laws of physics.
