### PR TITLE
Force successful return when installing VBox guest additions, as they will always fail due to missing X

### DIFF
--- a/definitions/ubuntu-7.10-server-amd64/postinstall.sh
+++ b/definitions/ubuntu-7.10-server-amd64/postinstall.sh
@@ -25,7 +25,20 @@ sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
 wget http://rubyforge.org/frs/download.php/71096/ruby-enterprise-1.8.7-2010.02.tar.gz
 tar xzvf ruby-enterprise-1.8.7-2010.02.tar.gz
 mkdir -p /opt/ruby/lib/ruby/gems/1.8/gems
-./ruby-enterprise-1.8.7-2010.02/installer -a /opt/ruby --no-dev-docs --dont-install-useful-gems
+
+# installer is broken, hack around it
+# see http://blog.martinlv.cawing.info/?p=93
+RUBYINST="./ruby-enterprise-1.8.7-2010.02/installer -a /opt/ruby --no-dev-docs --dont-install-useful-gems"
+HACKMSG="Ruby installer failed, trying to work around a known clock bug"
+DAY=`expr 24 '*' 3600`
+$RUBYINST || (
+    echo $HACKMSG
+    now=`date +%s`
+    sudo date -s @`expr $now '+' $DAY`
+    $RUBYINST
+    now=`date +%s`
+    sudo date -s @`expr $now '-' $DAY` )
+
 echo 'PATH=$PATH:/opt/ruby/bin/'>> /etc/profile
 rm -rf ./ruby-enterprise-1.8.7-2010.02/
 rm ruby-enterprise-1.8.7-2010.02.tar.gz
@@ -47,7 +60,8 @@ VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
 cd /tmp
 wget http://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso
 mount -o loop VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
-sh /mnt/VBoxLinuxAdditions.run
+# It will try to install X11 modules and fail, there's no way to prevent that
+sh /mnt/VBoxLinuxAdditions.run || true
 umount /mnt
 
 rm VBoxGuestAdditions_$VBOX_VERSION.iso


### PR DESCRIPTION
Unfortunately the installer is terrible and won't let us prevent that in any way, but veewee's cucumber tests verify GA's presence, so it doesn't matter that much in practice.
