### PR TITLE
Fix for several veewee setup problems

### DIFF
--- a/definitions/ubuntu-7.10-server-amd64/definition.rb
+++ b/definitions/ubuntu-7.10-server-amd64/definition.rb
@@ -17,7 +17,7 @@ Veewee::Definition.declare({
     'fb=false debconf/frontend=noninteractive ',
     'console-setup/ask_detect=false console-setup/modelcode=pc105 console-setup/layoutcode=us ',
     'initrd=/install/initrd.gz -- <Enter>'
-],
+  ],
   :kickstart_port => "7122",
   :kickstart_timeout => "10000",
   :kickstart_file => "preseed.cfg",

--- a/definitions/ubuntu-7.10-server-amd64/postinstall.sh
+++ b/definitions/ubuntu-7.10-server-amd64/postinstall.sh
@@ -49,7 +49,7 @@ VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
 cd /tmp
 wget http://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso
 mount -o loop VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
-sh /mnt/VBoxLinuxAdditions.run
+sh /mnt/VBoxLinuxAdditions.run || true
 umount /mnt
 
 rm VBoxGuestAdditions_$VBOX_VERSION.iso
@@ -75,7 +75,8 @@ echo "Adding a 2 sec delay to the interface up, to make the dhclient happy"
 echo "pre-up sleep 2" >> /etc/network/interfaces
 
 mv /usr/bin/sudo /usr/bin/sudo-real
-tee /usr/bin/sudo <<'LITERAL'
+(cat <<'LITERAL' > /usr/bin/sudo
+#!/bin/sh
 while 
   case "$@" in 
     '') false 
@@ -94,6 +95,7 @@ done
 
 /usr/bin/sudo-real $arglist || exit $?
 LITERAL
+) && chmod a+x /usr/bin/sudo
 
 # Zero out the free space to save space in the final image:
 dd if=/dev/zero of=/EMPTY bs=1M || rm -f /EMPTY || true

--- a/provision.sh
+++ b/provision.sh
@@ -79,5 +79,5 @@ echo 'HOME=/root vncserver -geometry 1150x900' >> /etc/rc.local
 
 echo "start opengenera under vnc"
 if [[ ! -f "/root/.vnc/genera-host:1.pid" ]]; then
-  vncserver -geometry 1150x900
+  HOME=/root sudo vncserver -geometry 1150x900
 fi

--- a/provisioning/run-genera
+++ b/provisioning/run-genera
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 wd=/var/lib/symbolics
-cmd="HOME=/root DISPLAY=:1 ./genera -geometry 1150x900 2>&1 > genera.log"
+cmd="./genera -geometry 1150x900 2>&1 > genera.log"
 pidfile="$wd/genera.pid"
 exec="$wd/genera"
-sudo /sbin/start-stop-daemon --start --background --quiet --oknodo \
+HOME=/root DISPLAY=:1 sudo /sbin/start-stop-daemon --start --background --quiet --oknodo \
 			--chdir "$wd" --exec "$exec" --startas /bin/bash -- -c "$cmd"
 

--- a/provisioning/vncxstartup
+++ b/provisioning/vncxstartup
@@ -21,5 +21,16 @@ sleep 2
 xterm &
 
 cd /var/lib/symbolics
-xterm -e /var/lib/symbolics/run-genera &
+/var/lib/symbolics/run-genera &
 
+#
+# This is a terrible hack. For reasons as yet unknown, the
+# first time Genera is launched after starting vncserver,
+# it comes up into a partially cold-booted state that is
+# unusable. At least for me, this happens 100% of the time.
+# Restarting it, likewise, always gets it running.
+#
+
+sleep 5
+
+exec /usr/local/bin/restart-genera &


### PR DESCRIPTION
It looks like there are two small issues with the veewee build of the ubuntu-7.10-server-amd64 base box. The following two changes allowed a base box to be built successfully for me.
1. The VBoxLinuxAdditions script exits with a non-zero status because there's no X11 installed. As a result, the veewee build was dying at that line and not going on. I think the non-zero exit from the script is OK, since we don't care about the X11 guest additions. The "|| true" will guarantee that the line always evaluates to true. While this works, it's probably not an ideal solution because has the chance to mask real failures as well. I hope it's OK.
2. The sudo script was not getting its executable bits set. I've put "&& chmod a+x /usr/bin/sudo" at the end of script heredoc so that it will get its executable bits set in the same shell operation as writing out the file.
